### PR TITLE
Replace dots of all keys to underscores

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,11 @@
   "fields":{
     "grpc.code":"OK",
     "grpc.method":"Auth",
-    "grpc.service":"pb.taeho.auth.AuthService",
-    "grpc.start_time":"2018-03-30T10:55:34-07:00",
-    "grpc.time_ms":0.25,
-    "peer.address":"127.0.0.1:61161",
-    "span.kind":"server",
+    "grpc_service":"pb.taeho.auth.AuthService",
+    "grpc_start_time":"2018-03-30T10:55:34-07:00",
+    "grpc_time_ms":0.25,
+    "peer_address":"127.0.0.1:61161",
+    "span_kind":"server",
     "system":"grpc"
   },
   "level":"info",

--- a/json_formatter.go
+++ b/json_formatter.go
@@ -3,6 +3,7 @@ package logrus
 import (
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/sirupsen/logrus"
@@ -72,6 +73,7 @@ func (f *ApexUpJSONFormatter) Format(entry *logrus.Entry) ([]byte, error) {
 	data := make(Fields, len(entry.Data)+3)
 	data["fields"] = make(map[string]interface{})
 	for k, v := range entry.Data {
+		k = strings.Replace(k, ".", "_", -1)
 		switch v := v.(type) {
 		case error:
 			// Otherwise errors are ignored by `encoding/json`


### PR DESCRIPTION
Since AWS CloudWatch Log filters do not support `.` within keys of JSON formatted logs.